### PR TITLE
add ability to append location to header

### DIFF
--- a/MMM-AirQuality.js
+++ b/MMM-AirQuality.js
@@ -11,6 +11,7 @@ Module.register('MMM-AirQuality', {
 		location: '',
 		showLocation: true,
 		showIndex: true,
+		appendLocationNameToHeader: true,
 		updateInterval: 30, // every 30 minutes
 		animationSpeed: 1000
 	},
@@ -52,6 +53,19 @@ Module.register('MMM-AirQuality', {
 	getStyles: function() {
 		return ['https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css'];
 	},
+        // Override getHeader method.
+        getHeader: function () {
+                var header = ""
+                if (this.data.header)
+                        header += this.data.header;
+                if (this.config.appendLocationNameToHeader) {
+                        if (header != "") {
+                                header += " ";
+                        }
+                        header += this.data.city;
+                }
+                return header
+        },
 	// Override dom generator.
 	getDom: function() {
 		var wrapper = document.createElement("div");
@@ -70,7 +84,7 @@ Module.register('MMM-AirQuality', {
 				this.html.icon,
 				this.data.impact,
 				(this.config.showIndex?' ('+this.data.value+')':''))+
-			(this.config.showLocation?this.html.city.format(this.data.city):'');
+			(this.config.showLocation && !this.config.appendLocationNameToHeader?this.html.city.format(this.data.city):'');
 		return wrapper;
 	}
 });

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You may want to set the following options in the config section as well:
 | `lang` | change the language<br><br>This is **OPTIONAL**.<br>**Default value:** `en` | 
 | `updateInterval` |  change the update period in minutes<br><br>This is **OPTIONAL**.<br>**Default value:** `30` (minutes) | 
 | `showLocation` | toggle location printing<br><br>This is **OPTIONAL**.<br>**Default value:**`true` |
+| `appendLocationNameToHeader` | If set to `true`, the returned location name will be appended to the header of the module.<br><br>**Default value:** `true` |
 | `showIndex` | toggle index printing<br><br>This is **OPTIONAL**.<br>**Default value:**`true` | 
 
 ### Known Issues


### PR DESCRIPTION
This add's the ability to enrich the header with the location name:

<img width="226" alt="Bildschirmfoto 2021-12-25 um 16 09 46" src="https://user-images.githubusercontent.com/9592452/147387981-4d6e3ca1-bcdf-4190-bf8f-a099877c0bf0.png">

replaces #12 

